### PR TITLE
Do we want coverage fail at 70 or 80?

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ passenv =
 commands =
     - coverage erase
     - pytest -q tests/ --cov=properimage --cov-append --cov-report=
-    coverage report --fail-under=70 -m --omit=properimage/tplibs/*
+    coverage report --fail-under=80 -m --omit=properimage/tplibs/*
 
 
 [testenv:docs]


### PR DESCRIPTION
Hey, I just noticed that tox.ini was set to fail at 70, but we're at 80% now. 
This is related to #31. I don't know if we want it to *necessarily fail* at 80?
You guys make the call.